### PR TITLE
Removed excessive error calling on timeout

### DIFF
--- a/reqwest.js
+++ b/reqwest.js
@@ -78,7 +78,6 @@
     if (o.timeout) {
       this.timeout = setTimeout(function () {
         self.abort();
-        error();
       }, o.timeout);
     }
 


### PR DESCRIPTION
Aborting a request will (at least when I tested in Firefox 4) result in readyState() invoking error() so having a timeout invoke it as well results in the error being invoked twice for the same request which can result in some unexpected things.
