### PR TITLE
Fix for IE when using callback=?

### DIFF
--- a/reqwest.js
+++ b/reqwest.js
@@ -45,7 +45,7 @@
 
   function getCallbackName(o) {
     var callbackVar = o.jsonpCallback || "callback";
-    if (o.url.substr(-(callbackVar.length + 2)) == (callbackVar + "=?")) {
+    if (o.url.slice(-(callbackVar.length + 2)) == (callbackVar + "=?")) {
       // Generate a guaranteed unique callback name
       var callbackName = "reqwest_" + uniqid++;
 


### PR DESCRIPTION
Fix for IE. When using substr with a negative number, IE returns the whole string instead of starting from the end. Ref: http://rapd.wordpress.com/2007/07/12/javascript-substr-vs-substring/
