### PR TITLE
When serializing form inputs of type password, text, and hidden, blank values were being sent as "true"

### DIFF
--- a/reqwest.js
+++ b/reqwest.js
@@ -215,7 +215,7 @@
       case 'radio':
         return el.checked ? n + '=' + (el.value ? enc(el.value) : true) + '&' : '';
       default: // text hidden password submit
-        return n + '=' + (el.value ? enc(el.value) : true) + '&';
+        return n + '=' + (el.value ? enc(el.value) : '') + '&';
       }
       break;
     case 'textarea':

--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -209,7 +209,7 @@
       case 'radio':
         return el.checked ? n + '=' + (el.value ? enc(el.value) : true) + '&' : '';
       default: // text hidden password submit
-        return n + '=' + (el.value ? enc(el.value) : true) + '&';
+        return n + '=' + (el.value ? enc(el.value) : '') + '&';
       }
       break;
     case 'textarea':


### PR DESCRIPTION
This doesn't seem to match the way that forms are usually sent (and so made things happen differently when submitting via this library and submitting with regular form submits), so I think it is a bug. Either way, patched here, both in the src dir and the top level reqwest.js (didnt change the minified, as that'll be regenerated anyway).
