### PR TITLE
Rename "failure" to "error" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ reqwest({
   success: function (resp) {
     qwery('#content').html(resp.content);
   },
-  failure: function (err) { }
+  error: function (err) { }
 });
 ```
 


### PR DESCRIPTION
Rename failure-callback to error-callback because failure-callback won't work.
