### PR TITLE
Always set headers on XHR, rather than only if there is data.

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -33,9 +33,9 @@
     headers['X-Requested-With'] = headers['X-Requested-With'] || 'XMLHttpRequest';
     if (options.data) {
       headers['Content-type'] = headers['Content-type'] || 'application/x-www-form-urlencoded';
-      for (var h in headers) {
-        headers.hasOwnProperty(h) && http.setRequestHeader(h, headers[h], false);
-      }
+    }
+    for (var h in headers) {
+      headers.hasOwnProperty(h) && http.setRequestHeader(h, headers[h], false);
     }
   }
 


### PR DESCRIPTION
As it stands `http.setRequestHeader` was only being called if `options.data` was truthy, so for a basic get request they were not being properly set.
