### PR TITLE
Fix capitalization for the Content-Type header

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -36,7 +36,7 @@
     }
 
     if (o.data) {
-      headers['Content-type'] = headers['Content-type'] || 'application/x-www-form-urlencoded'
+      headers['Content-Type'] = headers['Content-Type'] || 'application/x-www-form-urlencoded'
     }
     for (var h in headers) {
       headers.hasOwnProperty(h) && http.setRequestHeader(h, headers[h], false)


### PR DESCRIPTION
Sorry to be nit-picky but capitalization should be consistent, especially since there is no normalization of header names.
