### PR TITLE
IE9 calls both onload and onreadystatechange

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -84,10 +84,13 @@
       script.src = o.url
       script.async = true
 
-      script.onload = onload
-      // onload for IE
-      script.onreadystatechange = function () {
-        /^loaded|complete$/.test(script.readyState) && onload()
+      if (script.onload !== undefined) {
+          script.onload = onload
+      } else {
+          // onload for IE
+          script.onreadystatechange = function () {
+            /^loaded|complete$/.test(script.readyState) && onload()
+          }
       }
 
       // Add the script to the DOM head


### PR DESCRIPTION
They split the difference, those wise chaps, and call both events. Why not, you know?

/tired of 10 hours of IE debugging. this seems to fix things in IE9 and not break things elsewhere.
