### PR TITLE
use expires=0 in test server, fixes tests in IE9

### DIFF
--- a/make/tests.js
+++ b/make/tests.js
@@ -12,7 +12,7 @@ var routes = {
   },
 
   '(([a-zA-Z0-9_\\-\\/]+)\\.(css|js|json|html)$)': function (req, res, m, file, ext) {
-    res.writeHead(200, {'Content-Type': mime.lookup(ext)})
+    res.writeHead(200, {'Expires': 0, 'Cache-Control': 'max-age=0, no-cache, no-store', 'Content-Type': mime.lookup(ext)})
     res.write(fs.readFileSync('./' + file + '.' + ext))
     res.end()
   }


### PR DESCRIPTION
Just a tiny 1-line change in make/tests.js: I was going to log an issue report for the JSONP tests failing in IE9 when you re-run them in the same browser instance but I thought I'd first quickly investigate based on a hunch and it turned out to pay off. I'm not sure why this is a problem with IE9 alone (tho I'd suspect IE10 would be the same), all other browsers pass no matter how many times you reload, but IE9 seems to cache the <script>s that are used for JSONP calls and it messes things up (or something!). I imagine if anyone was serving up JSONP data then they'd probably be doing so using similar headers to what I've added to the test server here.
