### PR TITLE
Default accept headers

### DIFF
--- a/reqwest.js
+++ b/reqwest.js
@@ -43,8 +43,16 @@
   }
 
   function setHeaders(http, o) {
-    var headers = o.headers || {}
-    headers.Accept = headers.Accept || 'text/javascript, text/html, application/xml, text/xml, */*'
+    var headers = o.headers || {},
+     mimetypes= {
+      			xml: "application/xml, text/xml",
+      			html: "text/html",
+      			text: "text/plain",
+      			json: "application/json, text/javascript",
+      			js: 'application/javascript, text/javascript'
+      		}
+      headers.Accept = headers.Accept || mimetypes[o.type] || 'text/javascript, text/html, application/xml, text/xml, */*'
+//    headers.Accept = headers.Accept || 'text/javascript, text/html, application/xml, text/xml, */*'
 
     // breaks cross-origin requests with legacy browsers
     if (!o.crossOrigin) {

--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -37,8 +37,16 @@
   }
 
   function setHeaders(http, o) {
-    var headers = o.headers || {}
-    headers.Accept = headers.Accept || 'text/javascript, text/html, application/xml, text/xml, */*'
+    var headers = o.headers || {},
+     mimetypes= {
+      			xml: "application/xml, text/xml",
+      			html: "text/html",
+      			text: "text/plain",
+      			json: "application/json, text/javascript",
+      			js: 'application/javascript, text/javascript'
+      		}
+      headers.Accept = headers.Accept || mimetypes[o.type] || 'text/javascript, text/html, application/xml, text/xml, */*'
+//    headers.Accept = headers.Accept || 'text/javascript, text/html, application/xml, text/xml, */*'
 
     // breaks cross-origin requests with legacy browsers
     if (!o.crossOrigin) {


### PR DESCRIPTION
Send appropriate Accept headers regarding reqwest.type, instead of default 'text/javascript, text/html, application/xml, text/xml, _/_'

Signed-off-by: Nicolas nicolas.lesconnec.pro@gmail.com
