### PR TITLE
Changed reference to the global object from `this` to `Function('return t

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -1,14 +1,22 @@
 !function (name, definition) {
-  var global = Function('return this')();
+  var global = Function('return this')()
+    , old
+    
   if (typeof define == 'function') define(definition)
   else if (typeof module != 'undefined') module.exports = definition()
-  else global[name] = definition()
+  else {
+    old = global[name]
+    global[name] = definition()
+    global[name].noConflict = function () {
+      var self = global[name]
+      global[name] = old 
+      return self
+    }
+  }
 }('reqwest', function () {
 
-  var context = Function('return this')();
-    , win = window
+  var win = window
     , doc = document
-    , old = context.reqwest
     , twoHundo = /^20\d$/
     , byTag = 'getElementsByTagName'
     , readyState = 'readyState'
@@ -348,11 +356,6 @@
 
     // spaces should be + according to spec
     return qs.replace(/&$/, '').replace(/%20/g,'+')
-  }
-
-  reqwest.noConflict = function () {
-    context.reqwest = old
-    return this
   }
 
   return reqwest


### PR DESCRIPTION
Changed reference to the global object from `this` to `Function('return this')()`.

I can't see how in any context `context` would be anything but the global object. Using `this` as the global object breaks stuff when this is wrapped in a strict mode function.
