### PR TITLE
Enable timeout support for JSONP requests

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -76,6 +76,7 @@
       , match = url.match(cbreg)
       , script = doc.createElement('script')
       , loaded = 0
+      , failed = 0
       , self = this
 
     if (match) {
@@ -109,7 +110,7 @@
       script.onclick && script.onclick()
       // Call the user callback with the last value stored and clean up values and scripts.
       o.timeout && clearTimeout(self.timeout);
-      o.success && o.success(lastValue)
+      !failed && o.success && o.success(lastValue)
       lastValue = undefined
       head.removeChild(script)
       loaded = 1
@@ -119,7 +120,10 @@
     head.appendChild(script)
 
     // Enable JSONP timeout
-    return {abort: function(){ err && err() }}
+    return {abort: function(){
+        failed = 1
+        err & err()
+    }}
   }
 
   function getRequest(o, fn, err) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -42,7 +42,7 @@
       })
     })
 
-    test('JSONP', 18, function() {
+    test('JSONP', 19, function() {
       ajax({
         url: '/tests/fixtures/fixtures_jsonp.jsonp?callback=?',
         type: 'jsonp',
@@ -126,6 +126,19 @@
         success: function(resp) {
           ok(resp && resp.query, 'received response from echo callback')
           ok(resp && resp.query && resp.query.callback == 'reqwest_foo', 'correctly matched callback in URL')
+        }
+      })
+
+      ajax({
+        url: '/tests/fixtures/fixtures_jsonp2.jsonp',
+        type: 'jsonp',
+        jsopCallbackName: 'bar',
+        timeout: 1,
+        success: function(resp) {
+          ok(false, "timeout triggered success callback after error")
+        },
+        error: function() {
+          ok(true, "timeout triggered error callback")
         }
       })
     })


### PR DESCRIPTION
Return a dummy object from <code>handleJsonp()</code> that contains only an <code>abort()</code> method which calls the <code>err</code> function that's already passed to <code>handleJsonp()</code>.

 That's all we need for the normal timeout to work w/ JSONP requests.
