### PR TITLE
new version of sink with optional expectation arg

### DIFF
--- a/build.json
+++ b/build.json
@@ -21,5 +21,6 @@
     , "whitespace": true
     , "asi": true
     , "laxbreak": true
+    , "laxcomma": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   , "devDependencies": {
       "connect": "1.8.x"
     , "mime": "1.x.x"
-    , "sink-test": "0.x.x"
+    , "sink-test": ">=0.1.2"
     , "dispatch": "0.x.x"
     , "valentine": ">=1.4.7"
   }


### PR DESCRIPTION
`test('name', function (complete) { /* whatever */ complete() })` as an alternative to `test('name', 2, function () { ok(true); ok(true); })`

depends on https://github.com/ded/sink-test/pull/6 and an increment of Sink to 1.1.2.
