### PR TITLE
XML data type handling

### DIFF
--- a/make/tests.js
+++ b/make/tests.js
@@ -13,7 +13,7 @@ var routes = {
     res.write(fs.readFileSync('./tests/tests.html', 'utf8'))
     res.end()
   },
-  '(([\\w\\-\\/]+)\\.(css|js|json|jsonp|html)$)': function (req, res, next, uri, file, ext) {
+  '(([\\w\\-\\/]+)\\.(css|js|json|jsonp|html|xml)$)': function (req, res, next, uri, file, ext) {
     res.writeHead(200, {
         'Expires': 0
       , 'Cache-Control': 'max-age=0, no-cache, no-store'

--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -194,6 +194,9 @@
         case 'html':
           resp = r
           break;
+        case 'xml':
+          resp = resp.responseXML;
+          break;
         }
       }
 

--- a/tests/fixtures/badfixtures.xml
+++ b/tests/fixtures/badfixtures.xml
@@ -1,0 +1,1 @@
+Not a valid xml document

--- a/tests/fixtures/fixtures.xml
+++ b/tests/fixtures/fixtures.xml
@@ -1,0 +1,1 @@
+<root><boosh>boosh</boosh></root>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -75,6 +75,31 @@
         }
       })
     })
+    test('XML', 4, function(){
+     ajax({
+       url:'/tests/fixtures/fixtures.xml',
+       type:'xml',
+       success:function(resp){
+         ok(resp &&resp instanceof Document, 'XML Response is a Document')
+         ok(resp && resp.documentElement && resp.documentElement.nodeName=='root', 'XML Response root is <root>')
+         ok(resp && resp.documentElement && resp.documentElement.hasChildNodes && resp.documentElement.firstChild.nodeName=='boosh' && resp.documentElement.firstChild.firstChild.nodeValue==='boosh', 'Correct XML response')
+       },
+       error:function(err){
+         ok(false, err.responseText)
+       }
+     })
+
+     ajax({
+      url:'/tests/fixtures/badfixtures.xml',
+      type:'xml',
+      success:function(resp){
+        ok(resp===null, 'No XML Response')
+      },
+      error:function(err){
+        ok(true, 'No XML Response')
+      }
+     })
+   })
   })
 
   sink('JSONP', function (test, ok) {


### PR DESCRIPTION
Currently, a type:xml reqwest sends back the XmlHttpRequest object.

Now, it would send back the XML Document itself.

Updated tests.
