### PR TITLE
Kill onreadystatechange handler after readyState 4

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -43,6 +43,7 @@
   function handleReadyState(o, success, error) {
     return function () {
       if (o && o[readyState] == 4) {
+        o.onreadystatechange = undefined;
         if (twoHundo.test(o.status)) {
           success(o)
         } else {


### PR DESCRIPTION
There's a bug that apparently only affects a subset of Webkit browsers where if the execution is halted (through a debugger, for example), an xhr object can fire the readystatechange event (with 
readyState 4) multiple times (apparently, always 3 times). For reference, 
see:
- https://github.com/madrobby/zepto/pull/633
- http://code.google.com/p/chromium/issues/detail?id=159827

I'm also linking to 2 jsfiddles that illustrate the issue.
I was able to reproduce this behavior on Chrome 23 and mobile Safari on iOS 5 
(using remote debugging with an iPad) but not on (desktop) Safari 6 or Safari 5.1.

Steps to reproduce with first jsfiddle:
1. Open Chrome
2. Allow pop-ups 
3. Go to http://jsfiddle.net/MeXvJ/
4. Close the pop-up
5. You'll get 3 sequential alert boxes 

Steps to reproduce with second jsfiddle:
1. Open Chrome
2. Open Developer Tools
3. Go to http://jsfiddle.net/44b3P/
4. Unpause script execution in the debugger
5. You'll get 3 sequential alert boxes

Both jQuery and Zepto already do something similar to what I'm proposing. The 
difference is that they both set the onreadystatechange handler to a no-op 
function. Not sure why.
- jQuery: https://github.com/jquery/jquery/blob/master/src/ajax/xhr.js
- Zepto: https://github.com/madrobby/zepto/blob/master/src/ajax.js
