### PR TITLE
Make readystatechange handler a no-op on readyState 4

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -16,6 +16,7 @@
     , callbackPrefix = 'reqwest_' + (+new Date())
     , lastValue // data stored by the most recent JSONP callback
     , xmlHttpRequest = 'XMLHttpRequest'
+    , noop = function () {}
 
   var isArray = typeof Array.isArray == 'function' ? Array.isArray : function (a) {
     return a instanceof Array
@@ -43,7 +44,7 @@
   function handleReadyState(o, success, error) {
     return function () {
       if (o && o[readyState] == 4) {
-        o.onreadystatechange = undefined;
+        o.onreadystatechange = noop;
         if (twoHundo.test(o.status)) {
           success(o)
         } else {


### PR DESCRIPTION
Setting onreadystatechange to undefined causes an error to pop up 
in IE8:
http://jsbin.com/ulitew/1/edit 

Setting it to null also seems to create problems in earlier IE's:
https://issues.jboss.org/browse/JBSEAM-1271

Since setting it to a no-op is what jQuery does, I assume that this
is probably the most browser-compatible technique.
