### PR TITLE
IE9 may abort request if all event handlers not specified

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -181,6 +181,7 @@
     http.open(method, url, o.async === false ? false : true)
     setHeaders(http, o)
     setCredentials(http, o)
+    http.onprogress = function() {}
     http.onreadystatechange = handleReadyState(this, fn, err)
     o.before && o.before(http)
     http.send(data)


### PR DESCRIPTION
I was having this problem with a project, and I followed the fix explained in this post:

http://social.msdn.microsoft.com/Forums/ie/en-US/30ef3add-767c-4436-b8a9-f1ca19b4812e/
