### PR TITLE
Use hasOwnProperty for data

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -528,7 +528,7 @@
       // If traditional, encode the "old" way (the way 1.3.2 or older
       // did it), otherwise encode params recursively.
       for (prefix in o) {
-        buildParams(prefix, o[prefix], traditional, add)
+        if (o.hasOwnProperty(prefix)) buildParams(prefix, o[prefix], traditional, add)
       }
     }
 


### PR DESCRIPTION
Otherwise prototype methods of some data-classes's instances fall into query string
