### PR TITLE
Avoid default content type header when FormData

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -82,10 +82,11 @@
     headers['Accept'] = headers['Accept']
       || defaultHeaders['accept'][o['type']]
       || defaultHeaders['accept']['*']
-
+      
+    var isAFormData = FormData && (o['data'] instanceof FormData);
     // breaks cross-origin requests with legacy browsers
     if (!o['crossOrigin'] && !headers[requestedWith]) headers[requestedWith] = defaultHeaders['requestedWith']
-    if (!headers[contentType]) headers[contentType] = o['contentType'] || defaultHeaders['contentType']
+    if (!headers[contentType] && !isAFormData) headers[contentType] = o['contentType'] || defaultHeaders['contentType']
     for (h in headers)
       headers.hasOwnProperty(h) && 'setRequestHeader' in http && http.setRequestHeader(h, headers[h])
   }


### PR DESCRIPTION
When use a FormData in 'data' attr, this avoid the default header in order to avoid boundary creation problem. NOTE: In order to use a FormData in the 'data' attr is necesary set 'processData' as false.
