### PR TITLE
fix success determination when protocol != http(s)

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -6,6 +6,7 @@
 
   var win = window
     , doc = document
+    , httpsRe = /^http/
     , twoHundo = /^(20\d|1223)$/
     , byTag = 'getElementsByTagName'
     , readyState = 'readyState'
@@ -61,6 +62,10 @@
         }
       }
 
+  function succeed(request) {
+    return httpsRe.test(window.location.protocol) ? twoHundo.test(request.status) : !!request.response;
+  }
+
   function handleReadyState(r, success, error) {
     return function () {
       // use _aborted to mitigate against IE err c00c023f
@@ -68,7 +73,7 @@
       if (r._aborted) return error(r.request)
       if (r.request && r.request[readyState] == 4) {
         r.request.onreadystatechange = noop
-        if (twoHundo.test(r.request.status)) success(r.request)
+        if (succeed(r.request)) success(r.request)
         else
           error(r.request)
       }


### PR DESCRIPTION
When protocol != http(s) (i.e. file:// or any custom. I use ufs:// in my custom qtwebkit application) reqwest will handle it like an error, but these protocols cannot set xhr.status, so it is a case when we have the data in xhr.response, we have xhr.readyState == 4, but xhr.status == 0

So I added the check for protocol and if it is http(s) then use your old check, else we will see if xhr.response is truthy
