### PR TITLE
Separate inner and outer requests

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -7,7 +7,8 @@
   var win = window
     , doc = document
     , httpsRe = /^http/
-    , twoHundo = /^(20\d|1223)$/
+    , protocolRe = /(^\w+):\/\//
+    , twoHundo = /^(20\d|1223)$/ //http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request
     , byTag = 'getElementsByTagName'
     , readyState = 'readyState'
     , contentType = 'Content-Type'
@@ -62,8 +63,10 @@
         }
       }
 
-  function succeed(request) {
-    return httpsRe.test(window.location.protocol) ? twoHundo.test(request.status) : !!request.response;
+  function succeed(r) {
+    var protocol = protocolRe.exec(r.url);
+    protocol = (protocol && protocol[1]) || window.location.protocol;
+    return httpsRe.test(protocol) ? twoHundo.test(r.request.status) : !!r.request.response;
   }
 
   function handleReadyState(r, success, error) {
@@ -73,7 +76,7 @@
       if (r._aborted) return error(r.request)
       if (r.request && r.request[readyState] == 4) {
         r.request.onreadystatechange = noop
-        if (succeed(r.request)) success(r.request)
+        if (succeed(r)) success(r.request)
         else
           error(r.request)
       }


### PR DESCRIPTION
- Added comment to twoHundo IE's 1223 status code
- Fixed success determination if we make request not to HTTP. [Last time](https://github.com/ded/reqwest/commit/094ceefed65bf2049e937158caa3e93832206207) I made a mistake, when tried to check if **request is made FROM http or not**, but I should check if **request is made FOR http or not**. So now:
1. we'll check if the requested url has protocol
2. otherwise request is made for the inner resource, so we'll take window.location.protocol as requested protocol
3. we'll check this protocol from 1 || 2 for https
