### PR TITLE
Created bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "reqwest"
+  "main": "reqwest.min.js",
+  "ignore": [
+    ".jshintrc",
+    "tests",
+    "make",
+    "vendor",
+    ".gitignore",
+    ".travis.yml",
+    "Makefile",
+    "package.json",
+    "phantom.js",
+    "test.js",
+    "use-me.sublime-project"
+  ],
+  "dependencies": {},
+  "devDependencies": {}
+}


### PR DESCRIPTION
So it can be consumed as a dependency via bower. Version deliberately left out as bower will read tags in the repo.

If you decide to merge this it'd be great if you could also 
```
bower register reqwest https://github.com/ded/reqwest.git
```