### PR TITLE
Treat timeout differently than abort. Also added a string message to the...

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -74,6 +74,7 @@
       // use _aborted to mitigate against IE err c00c023f
       // (can't read props on aborted request objects)
       if (r._aborted) return error(r.request)
+      if (r._timedOut) return error(r.request, 'Request is aborted: timeout')
       if (r.request && r.request[readyState] == 4) {
         r.request.onreadystatechange = noop
         if (succeed(r)) success(r.request)
@@ -260,7 +261,7 @@
 
     if (o['timeout']) {
       this.timeout = setTimeout(function () {
-        self.abort()
+        timedOut()
       }, o['timeout'])
     }
 
@@ -336,6 +337,11 @@
       }
 
       complete(resp)
+    }
+
+    function timedOut() {
+      self._timedOut = true
+      self.request.abort()      
     }
 
     function error(resp, msg, t) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1784,10 +1784,11 @@
           url: '/tests/timeout'
         , type: 'json'
         , timeout: 250
-        , error: function (err) {
+        , error: function (err, msg) {
             ok(err, 'received error response')
             try {
               ok(err && err.status === 0, 'correctly caught timeout')
+              ok(msg && msg === 'Request is aborted: timeout', 'timeout message received')
             } catch (e) {
               ok(true, 'IE is a troll')
             }


### PR DESCRIPTION
... timeout response.

Wanted to treat timeouts differently to aborts (which is exposed by the library). A timed out request aborts the request and also send a message back to the caller (like in jQuery ajax). This way its a bit easier to determine that a timeout has occurred. Instead of just checking the status === 0 (which is the same for manually aborted requests), we can also check the response message to make sure that the request has timed out.
