### PR TITLE
Eval Scope

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -20,6 +20,7 @@
     , xmlHttpRequest = 'XMLHttpRequest'
     , xDomainRequest = 'XDomainRequest'
     , noop = function () {}
+    , gEval = function(s) { win.eval.call(win, s) }
 
     , isArray = typeof Array.isArray == 'function'
         ? Array.isArray
@@ -306,13 +307,13 @@
         switch (type) {
         case 'json':
           try {
-            resp = win.JSON ? win.JSON.parse(r) : eval('(' + r + ')')
+            resp = win.JSON ? win.JSON.parse(r) : gEval('(' + r + ')')
           } catch (err) {
             return error(resp, 'Could not parse JSON in response', err)
           }
           break
         case 'js':
-          resp = eval(r)
+          resp = gEval(r)
           break
         case 'html':
           resp = r
@@ -341,7 +342,7 @@
 
     function timedOut() {
       self._timedOut = true
-      self.request.abort()      
+      self.request.abort()
     }
 
     function error(resp, msg, t) {

--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -20,7 +20,7 @@
     , xmlHttpRequest = 'XMLHttpRequest'
     , xDomainRequest = 'XDomainRequest'
     , noop = function () {}
-    , gEval = function(s) { win.eval.call(win, s) }
+    , gEval = function(s) { return win.eval.call(win, s) }
 
     , isArray = typeof Array.isArray == 'function'
         ? Array.isArray

--- a/tests/fixtures/poison.js
+++ b/tests/fixtures/poison.js
@@ -1,0 +1,5 @@
+// Die immediately
+self = null
+
+// Common in global scope, e.g. Prism.js+File@
+// self = window

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1821,6 +1821,22 @@
     })
   })
 
+  sink('JavaScript', function (test, ok) {
+    test('Poisoning Scope Variables', function (complete) {
+      ajax({
+          url: '/tests/fixtures/poison.js'
+        , type: 'js'
+        , success: function () {
+            ok(
+                true // Enough to be here
+              , 'test cannot fail if reached'
+            )
+            complete()
+          }
+      })
+    })
+  })
+
   start()
 
 }(reqwest))


### PR DESCRIPTION
Plain eval reflects to local scope, basically anything can happen. Old or rare browsers might not offer win.eval. If that happens, requests to *.js will now fail if you merge.

One could check for *'function' == typeof win.eval* and provide a fallback on plain eval. But I suggest you do not. Results are quite unpredictable.