### PR TITLE
#160 Fix problem where no specificed content-type throws exceptions.

### DIFF
--- a/make/tests.js
+++ b/make/tests.js
@@ -27,6 +27,10 @@ var routes = {
         delayed.pipe(res)
       }, 2000)
   },
+  '/tests/204': function(req, res) {
+    res.writeHead(204);
+    res.end();
+  },
   '(([\\w\\-\\/\\.]+)\\.(css|js|json|jsonp|html|xml)$)': function (req, res, next, uri, file, ext) {
     res.writeHead(200, {
         'Expires': 0

--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -231,6 +231,7 @@
 
   function setType(header) {
     // json, javascript, text/plain, text/html, xml
+    if (header === null) return undefined; //In case of no content-type.
     if (header.match('json')) return 'json'
     if (header.match('javascript')) return 'js'
     if (header.match('text')) return 'html'

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -801,6 +801,15 @@
       })
     })
 
+    test('standard mode on no content-type', function (complete) {
+      ajax({
+        url: '/tests/204'
+          , success: function (resp) {
+            ok(true, 'Nothing blew up.')
+          }
+        })
+    })
+
     test('compat mode "dataType=json" headers', function (complete) {
       ajax.compat({
           url: '/tests/none.json?echo'


### PR DESCRIPTION
Fix for #160 
I ran into this yesterday and saw that a fix was easy enough.

If you don't specify the 'type' parameter to reqwest and the server doesn't send a content-type, an exception gets thrown when the content-type header is accessed as it doesn't exist.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7.2.1
>  Any HTTP/1.1 message containing an entity-body SHOULD include a Content-Type header field defining the media type of that body. If and only if the media type is not given by a Content-Type field, the recipient MAY attempt to guess the media type via inspection of its content and/or the name extension(s) of the URI used to identify the resource. If the media type remains unknown, the recipient SHOULD treat it as type "application/octet-stream". 

While the wording encourages supplying a content-type it is never stated to be required.

10 bytes larger when gzipped. 