### PR TITLE
Fix throw on 204

### DIFF
--- a/reqwest.js
+++ b/reqwest.js
@@ -237,6 +237,7 @@
 
   function setType(header) {
     // json, javascript, text/plain, text/html, xml
+    if (header == null) return 'text/plain' // could be null in the event of a 204 (nginx does this)
     if (header.match('json')) return 'json'
     if (header.match('javascript')) return 'js'
     if (header.match('text')) return 'html'


### PR DESCRIPTION
reqwest is throwing on 204 responses that don't have a content-type header (they're not required to, [since they have no body](https://tools.ietf.org/html/rfc2616#section-7.2.1)). This is happening for my server that sits behind nginx. Seems like nginx strips the content-type header when the status code is 204 (i tried explicitly sending the content-type to overcome this issue).