### PR TITLE
On 'DELETE' method, convert data to query string path

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -187,7 +187,7 @@
 
     // if we're working on a GET request and we have data then we should append
     // query string to end of URL and not post data
-    if ((o['type'] == 'jsonp' || method == 'GET') && data) {
+    if ((o['type'] == 'jsonp' || method == 'GET' || method == 'DELETE') && data) {
       url = urlappend(url, data)
       data = null
     }
@@ -341,7 +341,7 @@
 
     function timedOut() {
       self._timedOut = true
-      self.request.abort()      
+      self.request.abort()
     }
 
     function error(resp, msg, t) {


### PR DESCRIPTION
On RFC-7231(https://tools.ietf.org/html/rfc7231#section-4.3.5) 
>  A payload within a DELETE request message has no defined semantics;
>  sending a payload body on a DELETE request might cause some existing
>  implementations to reject the request.
So I think DELETE method should use query string rather than message body

CC. @yeonhoyoon 