### PR TITLE
Ignore vendor/phantomjs when publishing to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+vendor/phantomjs


### PR DESCRIPTION
The phantomjs binary adds ~9MB to the npm package. Adding vendor/phantomjs to .npmignore should reduce the download size to a few hundred KB.

See also issue #181 