### PR TITLE
ignore xhr2 for packager

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   },
   "main": "./reqwest.js",
   "ender": "./src/ender.js",
+  "browser": {
+    "xhr2": false
+  },
   "devDependencies": {
     "connect": "1.8.x",
     "mime": "1.x.x",

--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -13,9 +13,7 @@
   } else {
     var XHR2
     try {
-      // prevent browserify including xhr2
-      var xhr2 = 'xhr2'
-      XHR2 = require(xhr2)
+      XHR2 = require('xhr2')
     } catch (ex) {
       throw new Error('Peer dependency `xhr2` required! Please npm install xhr2')
     }


### PR DESCRIPTION
Current way does not work for webpack.

This is the right way to ignore xhr2 for web packager, such as browserify/webpack.

https://gist.github.com/defunctzombie/4339901