### PR TITLE
reqwest working in react-native

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -6,7 +6,7 @@
 
   var context = this
 
-  if ('window' in context) {
+  if ('document' in context) {
     var doc = document
       , byTag = 'getElementsByTagName'
       , head = doc[byTag]('head')[0]


### PR DESCRIPTION
By changing the `'window' in context` check to `'document' in context` I was able to use reqwest in React Native. The environment in React Native contains a `window`, but has no `document`.

Would you consider applying this change? It does not have any negative side effects that I can see.