### PR TITLE
Release 2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "async",
     "sync"
   ],
-  "version": "2.0.5",
+  "version": "2.0.6",
   "homepage": "https://github.com/ded/reqwest",
   "author": "Dustin Diaz <dustin@dustindiaz.com> (http://dustindiaz.com)",
   "repository": {


### PR DESCRIPTION
Release 2.0.6 with the fix required for react-native.  The fix has already been merged, but it would be nice if a new publish to npm was made from master.
